### PR TITLE
Fixed appointment date allowing historic dates.

### DIFF
--- a/shopyo/templates/appointment/add.html
+++ b/shopyo/templates/appointment/add.html
@@ -24,8 +24,8 @@
             <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-calendar-day"></i></span>
             </div>
-            <input required autocomplete="off" id="date" type="date" class="form-control" name="date"
-                   placeholder="">
+            <input id="noHistoricDates" required autocomplete="off" id="date" type="date" class="form-control" name="date"
+                   min="" placeholder="">
         </div>
         <div class="input-group mb-3">
             <div class="input-group-prepend">
@@ -42,5 +42,13 @@
              <input required type="submit" class="btn btn-info" value="add">
         </div>
 
+        <script>
+            // Limit appointment date selections to current date and the future.
+            // Format is yyyy-mm-dd according to section 2.4.5.2 of the W3C HTML 5.2 spec:
+            // https://www.w3.org/TR/html52/infrastructure.html#valid-date-string
+            (function() {
+                document.getElementById("noHistoricDates").setAttribute("min", new Date().toISOString().split("T")[0]);
+            })();
+        </script>
     </form>
 {% endblock %}


### PR DESCRIPTION
Hi,

responding to issue: appointment_add allows historic dates. #19

Now historic dates are no longer available for selection after a new appointment is being made. Uses HTML5 date min -feature.

I'm going for Hacktoberfest 2019 and read the guy working on this issue stopped working on it, so I decided to step in, I hope that's cool?

![fix](https://user-images.githubusercontent.com/18207787/66275060-abb04700-e88d-11e9-9d75-0c16fa0f3b7b.gif)
