### PR TITLE
fix: Fixed html title tags for consistency

### DIFF
--- a/shopyo/modules/admin/templates/admin/edit.html
+++ b/shopyo/modules/admin/templates/admin/edit.html
@@ -3,7 +3,7 @@
 {% set active_page = "admin" %}
 
 {% block pagehead %}
-    <title>edit</title>
+    <title>Edit</title>
 {% endblock %}
 
 {% block content %}

--- a/shopyo/modules/appointment/templates/appointment/add.html
+++ b/shopyo/modules/appointment/templates/appointment/add.html
@@ -3,7 +3,7 @@
 {% set active_page = "appointments" %}
 
 {% block pagehead %}
-    <title>add appointment</title>
+    <title>Add Appointment</title>
 {% endblock %}
 
 {% block content %}

--- a/shopyo/modules/appointment/templates/appointment/edit.html
+++ b/shopyo/modules/appointment/templates/appointment/edit.html
@@ -3,7 +3,7 @@
 {% set active_page = "appointments" %}
 
 {% block pagehead %}
-    <title>edit</title>
+    <title>Edit</title>
 {% endblock %}
 
 {% block content %}

--- a/shopyo/modules/appointment/templates/appointment/lookup.html
+++ b/shopyo/modules/appointment/templates/appointment/lookup.html
@@ -3,7 +3,7 @@
 {% set active_page = "appointments" %}
 
 {% block pagehead %}
-    <title>add appointment</title>
+    <title>Add Appointment</title>
     <style>
         html {
         scroll-behavior: smooth;

--- a/shopyo/modules/manufacturer/templates/manufac/add.html
+++ b/shopyo/modules/manufacturer/templates/manufac/add.html
@@ -3,7 +3,7 @@
 {% set active_page ='manufacturer' %}
 
 {% block pagehead %}
-<title>add manufacturer</title>
+<title>Add Manufacturer</title>
 {% endblock %}
 
 {% block content %}

--- a/shopyo/modules/manufacturer/templates/manufac/edit.html
+++ b/shopyo/modules/manufacturer/templates/manufac/edit.html
@@ -3,7 +3,7 @@
 {% set active_page ='manufacturer' %}
 
 {% block pagehead %}
-<title>edit</title>
+<title>Edit</title>
 {% endblock %}
 
 {% block content %}

--- a/shopyo/modules/manufacturer/templates/manufac/index.html
+++ b/shopyo/modules/manufacturer/templates/manufac/index.html
@@ -3,7 +3,7 @@
 {% set active_page ='manufacturer' %}
 
 {% block pagehead %}
-<title>SpareParts</title>
+<title>Manufacturer</title>
 <style>
   .hidden{
     display: none;

--- a/shopyo/modules/people/templates/people/add.html
+++ b/shopyo/modules/people/templates/people/add.html
@@ -3,7 +3,7 @@
 {% set active_page ='people' %}
 
 {% block pagehead %}
-<title>add people</title>
+<title>Add People</title>
 {% endblock %}
 
 {% block content %}

--- a/shopyo/modules/people/templates/people/edit.html
+++ b/shopyo/modules/people/templates/people/edit.html
@@ -3,7 +3,7 @@
 {% set active_page ='people' %}
 
 {% block pagehead %}
-<title>edit</title>
+<title>Edit</title>
 {% endblock %}
 
 {% block content %}

--- a/shopyo/modules/people/templates/people/lookup.html
+++ b/shopyo/modules/people/templates/people/lookup.html
@@ -3,7 +3,7 @@
 {% set active_page = "people" %}
 
 {% block pagehead %}
-    <title>add people</title>
+    <title>Add People</title>
     <style>
         html {
         scroll-behavior: smooth;

--- a/shopyo/modules/products/templates/prods/add.html
+++ b/shopyo/modules/products/templates/prods/add.html
@@ -3,7 +3,7 @@
 {% set active_page ='products' %}
 
 {% block pagehead %}
-<title>add product</title>
+<title>Add Product</title>
 {% endblock %}
 
 {% block content %}

--- a/shopyo/modules/products/templates/prods/edit.html
+++ b/shopyo/modules/products/templates/prods/edit.html
@@ -3,7 +3,7 @@
 {% set active_page ='products' %}
 
 {% block pagehead %}
-<title>edit</title>
+<title>Edit</title>
 {% endblock %}
 
 {% block content %}

--- a/shopyo/modules/products/templates/prods/list.html
+++ b/shopyo/modules/products/templates/prods/list.html
@@ -3,7 +3,7 @@
 {% set active_page ='products' %}
 
 {% block pagehead %}
-<title>SpareParts</title>
+<title>Products</title>
 {% endblock %}
 
 {% block content %}

--- a/shopyo/modules/products/templates/prods/lookup.html
+++ b/shopyo/modules/products/templates/prods/lookup.html
@@ -3,7 +3,7 @@
 {% set active_page ='products' %}
 
 {% block pagehead %}
-<title>lookup</title>
+<title>Products</title>
 {% endblock %}
 
 {% block content %}

--- a/shopyo/modules/settings/templates/settings/edit.html
+++ b/shopyo/modules/settings/templates/settings/edit.html
@@ -3,7 +3,7 @@
 {% set active_page ='settings' %}
 
 {% block pagehead %}
-<title>edit</title>
+<title>Edit</title>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Fixed content of the title tags.
They were wrong or inconsistent with Capitalising the first char
This solved the wrong title for the page.

resolves: #22